### PR TITLE
Fix server-client player steel piston double fling

### DIFF
--- a/src/main/java/useless/fixer/mixin/BlockLogicPistonBaseSteelMixin.java
+++ b/src/main/java/useless/fixer/mixin/BlockLogicPistonBaseSteelMixin.java
@@ -1,0 +1,27 @@
+package useless.fixer.mixin;
+
+import net.minecraft.core.Global;
+import net.minecraft.core.block.piston.BlockLogicPistonBaseSteel;
+import net.minecraft.core.entity.Entity;
+import net.minecraft.core.entity.player.Player;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(value = BlockLogicPistonBaseSteel.class, remap = false)
+public class BlockLogicPistonBaseSteelMixin {
+	@Redirect(
+		method = "extendEvent",
+		at = @At(
+			value = "INVOKE",
+			target = "Lnet/minecraft/core/entity/Entity;fling(DDDF)V"
+		)
+	)
+	private void redirectFling(Entity entity, double x, double y, double z, float strength) {
+		if (!Global.isServer && entity.world != null && entity instanceof Player && entity.world.isClientSide) {
+			return;
+		}
+
+		entity.fling(x, y, z, strength);
+	}
+}

--- a/src/main/resources/fixer.mixins.json
+++ b/src/main/resources/fixer.mixins.json
@@ -15,6 +15,7 @@
     "TileEntityFurnaceMixin"
   ],
   "client": [
+    "BlockLogicPistonBaseSteelMixin",
     "BlockModelBasketMixin",
     "BlockModelChestMixin",
     "BlockModelDispatcherMixin",


### PR DESCRIPTION
*This fix this bug report https://bugs.betterthanadventure.net/tickets.php?id=229*

The reinforced piston is an amazing block added in 7.3 and with that we can finally create some awesome elevator with it !

In my single player the piston fling up to 18 blocks since this is the maximum height the reinforced piston throw the player.

But if I place it on a server and push the reinforced piston. It will throw the player around 34 blocks !

This PR propose to add a check before we fling the player by checking if the entity is the player and if true, if we are connected to a server.

This code check with `Global.isServer` even if the mixin is never injected on server because I consider it like a direct patch for BTA and BTA can't easily make a part of a method client only and I can't use the concrete instance of the LocalPlayer since it would make the server crash.